### PR TITLE
Functions for generating all-background, negative example data

### DIFF
--- a/src/shrub_prepro/images.py
+++ b/src/shrub_prepro/images.py
@@ -117,7 +117,6 @@ def background_samples(
     shrub_union = shrub_buffer.unary_union
 
     # Determine the number of negative samples to generate
-    # Let's start with 5 times the number of positive examples (shrubs)
     num_positive_samples = len(shrubs)
     num_negative_samples = num_positive_samples * 2  # Adjust this ratio as needed
 

--- a/src/shrub_prepro/images.py
+++ b/src/shrub_prepro/images.py
@@ -3,6 +3,9 @@ import geopandas as gpd
 from rasterio.windows import Window
 from shapely.geometry import box
 from rasterio.features import rasterize
+import random
+import numpy as np
+import logging
 
 
 def patch_window(
@@ -77,3 +80,112 @@ def label_patch_with_window(
         default_value=255,
     )
     return arr
+
+
+def background_samples(
+    image: rasterio.io.DatasetReader, shrubs: gpd.GeoDataFrame, window_size: int = 256
+) -> list:
+    """
+    Generate negative samples (background patches) from the image that do not overlap with shrub polygons.
+
+    Parameters:
+        image (rasterio.io.DatasetReader): Opened rasterio dataset of the image.
+        shrubs (gpd.GeoDataFrame): GeoDataFrame containing shrub polygons.
+
+    Returns:
+        list: List of rasterio.windows.Window objects representing negative samples.
+    """
+
+    # Get the bounding box of the image
+    img_bounds = image.bounds
+
+    # Buffer the shrub polygons slightly to ensure negative windows don't touch them
+    shrub_buffer = shrubs.copy()
+    # Adjust buffer distance based on your data's CRS units.
+    # If it's meters, a small buffer like 1-5 meters is reasonable.
+    # If it's degrees, you might need a smaller value or reproject.
+    # Assuming CRS is in meters based on the previous context, buffer by 5 meters.
+    try:
+        shrub_buffer["geometry"] = shrub_buffer.geometry.buffer(5)
+    except Exception as e:
+        logging.info(
+            f"Could not buffer polygons, likely due to CRS or geometry issues: {e}"
+        )
+        logging.info("Proceeding without buffering, this might lead to minor overlaps.")
+        shrub_buffer = shrubs  # Use original shrubs if buffering fails
+
+    shrub_union = shrub_buffer.unary_union
+
+    # Determine the number of negative samples to generate
+    # Let's start with 5 times the number of positive examples (shrubs)
+    num_positive_samples = len(shrubs)
+    num_negative_samples = num_positive_samples * 2  # Adjust this ratio as needed
+
+    negative_windows = []  # Set up a list of empty patches
+
+    # Generate random points within the image bounds until we have enough negative windows
+    logging.info(f"Attempting to generate {num_negative_samples} negative windows...")
+    attempts = 0
+    max_attempts = num_negative_samples * 10  # Limit attempts to avoid infinite loops
+
+    while len(negative_windows) < num_negative_samples and attempts < max_attempts:
+        # Generate a random point within the image bounds
+        rand_x = random.uniform(img_bounds.left, img_bounds.right)
+        rand_y = random.uniform(img_bounds.bottom, img_bounds.top)
+
+        # Convert random coordinates to pixel row and column
+        try:
+            row, col = image.index(rand_x, rand_y)
+        except rasterio.errors.CRSError:
+            # This can happen if the coordinates are slightly outside valid range due to float precision
+            attempts += 1
+            continue
+        except Exception as e:
+            logging.info(f"Error converting coordinates to index: {e}")
+            attempts += 1
+            continue
+
+        # Create a potential window centered at the random point
+        half_patch = window_size // 2
+        potential_window = Window(
+            col - half_patch, row - half_patch, window_size, window_size
+        )
+
+        # Calculate the geographic bounds of the potential window
+        window_bounds = rasterio.windows.bounds(potential_window, image.transform)
+        window_bbox = box(*window_bounds)
+
+        # Check if the potential window is entirely within the image bounds
+        if not box(*img_bounds).contains(window_bbox):
+            attempts += 1
+            continue
+
+        # Check if the potential window overlaps with any shrub polygon (or buffer)
+        # Convert the window bbox to a GeoDataFrame for intersection check
+        window_gdf = gpd.GeoDataFrame([1], geometry=[window_bbox], crs=image.crs)
+
+        # Perform the intersection check
+        if shrub_union is not None:
+            overlap = window_gdf.iloc[0].geometry.intersects(shrub_union)
+        else:
+            # No shrubs, no overlap to check
+            overlap = False
+
+        # If there is no overlap, add the window to our list
+        if overlap:
+            attempts += 1
+            continue
+
+        # Check for more than one distinct pixel value - a lot of our image is nodata
+        window_data = image.read(window=potential_window)
+
+        if len(np.unique(window_data)) > 1:
+            negative_windows.append(potential_window)
+
+        attempts += 1
+    return negative_windows
+
+
+def background_label(size: int = 256) -> np.ndarray:
+    """Return a 2D array of size*size all zeros, for use as a background label (no features)"""
+    return np.zeros((size, size), dtype=np.uint8)

--- a/src/shrub_prepro/processing.py
+++ b/src/shrub_prepro/processing.py
@@ -4,10 +4,14 @@ import geopandas as gpd
 import rasterio
 import tqdm
 from pathlib import Path
+
+
 from shrub_prepro.images import (
     patch_window,
     label_patch_with_window,
     shrub_labels_in_window,
+    background_samples,
+    background_label,
 )
 from shrub_prepro.io import save_image_patch, save_label_patch
 
@@ -51,3 +55,13 @@ def process_data(
             arr = label_patch_with_window(labels, window, image)
             save_image_patch(window, image, index, label=label, dir=images_dir)
             save_label_patch(arr, window, image, index, label=label, dir=labels_dir)
+
+        negative_windows = background_samples(image, shrubs)
+        for index, neg_window in enumerate(
+            tqdm(negative_windows, total=len(negative_windows))
+        ):
+            save_image_patch(neg_window, image, index, label="negative", dir="images")
+
+        save_label_patch(
+            background_label(), window, image, 0, label="negative", dir="train/labels"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+import numpy as np
+import rasterio
+from rasterio.transform import from_bounds
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+
+@pytest.fixture
+def sample_raster(tmp_path):
+    """Create a 3-band 20x20 raster with realistic UTM bounds."""
+    raster_path = tmp_path / "sample.tif"
+    width = height = 20
+    # Use UTM coordinates (meters), e.g., somewhere in central Europe
+    bounds = (500000, 0, 502000, 2000)  # left, bottom, right, top
+    transform = from_bounds(*bounds, width, height)
+    data = np.random.randint(0, 255, size=(3, height, width), dtype=np.uint8)
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=3,
+        dtype=np.uint8,
+        crs="EPSG:32633",  # UTM zone 33N
+        transform=transform,
+    ) as dst:
+        dst.write(data)
+    return raster_path
+
+
+@pytest.fixture
+def sample_polygons(tmp_path):
+    """Create a GeoDataFrame with a few polygons within the raster bounds (UTM meters)."""
+    # These polygons are within the (500000,0)-(502000,2000) bounds
+    polys = [
+        Polygon([(500100, 1100), (500300, 1100), (500300, 1300), (500100, 1300)]),
+        Polygon([(501000, 1000), (501200, 1000), (501200, 1200), (501000, 1200)]),
+        Polygon([(500400, 1600), (500600, 1600), (500600, 1800), (500400, 1800)]),
+    ]
+    gdf = gpd.GeoDataFrame({"geometry": polys}, crs="EPSG:32633")
+    poly_path = tmp_path / "sample_polygons.gpkg"
+    gdf.to_file(poly_path, driver="GPKG")
+    return poly_path

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,58 @@
+import numpy as np
+import rasterio
+import geopandas as gpd
+from shrub_prepro import images
+
+
+def test_patch_window(sample_polygons, sample_raster):
+    """Test patch_window returns a valid rasterio window of correct size."""
+    gdf = gpd.read_file(sample_polygons)
+    with rasterio.open(sample_raster) as img:
+        window = images.patch_window(gdf.geometry.iloc[0], img, patch_size=8)
+        assert isinstance(window, rasterio.windows.Window)
+        assert window.width == 8
+        assert window.height == 8
+
+
+def test_shrub_labels_in_window(sample_polygons, sample_raster):
+    """Test shrub_labels_in_window returns intersecting geometries."""
+    gdf = gpd.read_file(sample_polygons)
+    with rasterio.open(sample_raster) as img:
+        window = images.patch_window(gdf.geometry.iloc[0], img, patch_size=10)
+        intersecting = images.shrub_labels_in_window(gdf.geometry, window, img)
+        assert isinstance(intersecting, gpd.GeoSeries)
+        assert not intersecting.empty
+
+
+def test_label_patch_with_window(sample_polygons, sample_raster):
+    """Test label_patch_with_window returns a correct rasterized array."""
+    gdf = gpd.read_file(sample_polygons)
+    with rasterio.open(sample_raster) as img:
+        window = images.patch_window(gdf.geometry.iloc[0], img, patch_size=10)
+        intersecting = images.shrub_labels_in_window(gdf.geometry, window, img)
+        arr = images.label_patch_with_window(intersecting, window, img)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (10, 10)
+        assert np.any(arr == 255)
+
+
+def test_background_label():
+    """Test background_label returns a zero array of the correct size and type."""
+    arr = images.background_label(size=32)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (32, 32)
+    assert np.all(arr == 0)
+    assert arr.dtype == np.uint8
+
+
+def test_background_samples(sample_polygons, sample_raster):
+    """Test background_samples returns a list of windows with expected properties."""
+    gdf = gpd.read_file(sample_polygons)
+    with rasterio.open(sample_raster) as img:
+        negatives = images.background_samples(img, gdf, window_size=8)
+        assert isinstance(negatives, list)
+        assert all(isinstance(w, rasterio.windows.Window) for w in negatives)
+        # Each window should be the correct size
+        for w in negatives:
+            assert w.width == 8
+            assert w.height == 8


### PR DESCRIPTION
Mostly generated code ported back from the workshop notebook to the package. Add an appreciable amount of background-only examples to the training set to discourage the model from overfitting

* Randomly sample a tiff for patches that don't intersect with a set of geometries and are not nodata
* Create a blank label
* Save both the above along with our set of training data
* Minimal, also generated tests for the revised image processing functions