### PR TITLE
Ensure we can run training via the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.pyc
 .venv
+.env
 *.egg-info
 # Ignore system files
 .DS_Store

--- a/src/shrub_prepro/cli.py
+++ b/src/shrub_prepro/cli.py
@@ -1,4 +1,7 @@
 from shrub_prepro.run_pipeline import main
+from dotenv import load_dotenv
+
+load_dotenv()
 
 if __name__ == "__main__":
     main()

--- a/src/shrub_prepro/images.py
+++ b/src/shrub_prepro/images.py
@@ -50,8 +50,7 @@ def shrub_labels_in_window(
     Returns:
         gpd.GeoSeries: Series of geometries intersecting the window, with empty geometries removed.
     """
-    transform = rasterio.windows.transform(window, image.transform)
-    bounds = rasterio.windows.bounds(window, transform)
+    bounds = rasterio.windows.bounds(window, image.transform)
     bbox = box(*bounds)
     s = geometries.intersection(bbox)
     out_series = s[~(s.is_empty)]

--- a/src/shrub_prepro/images.py
+++ b/src/shrub_prepro/images.py
@@ -82,7 +82,7 @@ def label_patch_with_window(
 
 
 def background_samples(
-    image: rasterio.io.DatasetReader, shrubs: gpd.GeoDataFrame, window_size: int = 256
+    image: rasterio.io.DatasetReader, shrubs: gpd.GeoDataFrame, window_size: int = 512
 ) -> list:
     """
     Generate negative samples (background patches) from the image that do not overlap with shrub polygons.
@@ -184,6 +184,8 @@ def background_samples(
     return negative_windows
 
 
-def background_label(size: int = 256) -> np.ndarray:
-    """Return a 2D array of size*size all zeros, for use as a background label (no features)"""
+def background_label(size: int = 512) -> np.ndarray:
+    """Return a 2D array of size*size all zeros, for use as a background label (no features)
+    Defaults to size 512 input"""
+
     return np.zeros((size, size), dtype=np.uint8)

--- a/src/shrub_prepro/io.py
+++ b/src/shrub_prepro/io.py
@@ -24,7 +24,7 @@ def save_label_patch(
     image: rasterio.DatasetReader,
     index: int,
     label: str = "shrubs",
-    dir: str = "labels",
+    directory: str = "labels",
 ) -> None:
     """
     Save a single-channel label patch as a GeoTIFF file.
@@ -51,7 +51,7 @@ def save_label_patch(
         }
     )
 
-    original_path = os.path.join(dir, f"{label}_{index}.tif")
+    original_path = os.path.join(directory, f"{label}_{index}.tif")
     with rasterio.open(original_path, "w", **meta) as dst:
         dst.write(data, 1)
 
@@ -61,7 +61,7 @@ def save_image_patch(
     image: rasterio.DatasetReader,
     index: int,
     label: str = "shrubs",
-    dir: str = "images",
+    directory: str = "images",
 ) -> rasterio.DatasetReader:
     """
     Save a multi-channel image patch as a GeoTIFF file.
@@ -89,6 +89,6 @@ def save_image_patch(
         }
     )
 
-    original_path = os.path.join(dir, f"{label}_{index}.tif")
+    original_path = os.path.join(directory, f"{label}_{index}.tif")
     with rasterio.open(original_path, "w", **meta) as dst:
         dst.write(image_patch)

--- a/src/shrub_prepro/processing.py
+++ b/src/shrub_prepro/processing.py
@@ -53,15 +53,19 @@ def process_data(
             window = patch_window(shrub.geometry, image, patch_size=window_size)
             labels = shrub_labels_in_window(shrubs, window, image)
             arr = label_patch_with_window(labels, window, image)
-            save_image_patch(window, image, index, label=label, dir=images_dir)
-            save_label_patch(arr, window, image, index, label=label, dir=labels_dir)
+            save_image_patch(window, image, index, label=label, directory=images_dir)
+            save_label_patch(
+                arr, window, image, index, label=label, directory=labels_dir
+            )
 
         negative_windows = background_samples(image, shrubs)
         for index, neg_window in enumerate(
             tqdm(negative_windows, total=len(negative_windows))
         ):
-            save_image_patch(neg_window, image, index, label="negative", dir="images")
+            save_image_patch(
+                neg_window, image, index, label="negative", directory=images_dir
+            )
 
         save_label_patch(
-            background_label(), window, image, 0, label="negative", dir="train/labels"
+            background_label(), window, image, 0, label="negative", directory=labels_dir
         )

--- a/src/shrub_prepro/processing.py
+++ b/src/shrub_prepro/processing.py
@@ -2,7 +2,7 @@ import os
 
 import geopandas as gpd
 import rasterio
-import tqdm
+from tqdm import tqdm
 from pathlib import Path
 
 

--- a/src/shrub_prepro/processing.py
+++ b/src/shrub_prepro/processing.py
@@ -48,7 +48,7 @@ def process_data(
         shrubs = gpd.read_file(shapefile_path)
 
         for index, shrub in tqdm(
-            shrubs.iterrows(), total=len(shrubs), desc="Processing Samples"
+            shrubs.iterrows(), total=len(shrubs), desc="Shrub images and labels"
         ):
             window = patch_window(shrub.geometry, image, patch_size=window_size)
             labels = shrub_labels_in_window(shrubs, window, image)
@@ -58,9 +58,14 @@ def process_data(
                 arr, window, image, index, label=label, directory=labels_dir
             )
 
+        print("Selecting background examples")
         negative_windows = background_samples(image, shrubs)
         for index, neg_window in enumerate(
-            tqdm(negative_windows, total=len(negative_windows))
+            tqdm(
+                negative_windows,
+                total=len(negative_windows),
+                desc="Background images and labels",
+            )
         ):
             save_image_patch(
                 neg_window, image, index, label="negative", directory=images_dir

--- a/src/shrub_prepro/run_pipeline.py
+++ b/src/shrub_prepro/run_pipeline.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from shrub_prepro.processing import process_data
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="Process shrub data from RGB imagery")
     parser.add_argument(
         "--input-raster", required=True, help="S3 path or local path to input raster"
@@ -24,3 +24,7 @@ if __name__ == "__main__":
     print("Preparing training data...")
 
     process_data(args.input_raster, args.input_polygons, output_dir, label=args.label)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shrub_prepro/run_pipeline.py
+++ b/src/shrub_prepro/run_pipeline.py
@@ -14,7 +14,9 @@ def main():
         help="S3 path or local path to input polygons",
     )
     parser.add_argument("--output-dir", required=True, help="Output directory (local)")
-    parser.add_argument("--output-size", default=512, help="Patch size (default 512)")
+    parser.add_argument(
+        "--output-size", default=512, type=int, help="Patch size (default 512)"
+    )
     parser.add_argument("--label", default="rgb", help="Label for output files")
 
     args = parser.parse_args()

--- a/src/shrub_prepro/run_pipeline.py
+++ b/src/shrub_prepro/run_pipeline.py
@@ -14,6 +14,7 @@ def main():
         help="S3 path or local path to input polygons",
     )
     parser.add_argument("--output-dir", required=True, help="Output directory (local)")
+    parser.add_argument("--output-size", default=512, help="Patch size (default 512)")
     parser.add_argument("--label", default="rgb", help="Label for output files")
 
     args = parser.parse_args()
@@ -23,7 +24,13 @@ def main():
     # Pipeline steps
     print("Preparing training data...")
 
-    process_data(args.input_raster, args.input_polygons, output_dir, label=args.label)
+    process_data(
+        args.input_raster,
+        args.input_polygons,
+        output_dir,
+        window_size=args.output_size,
+        label=args.label,
+    )
 
 
 if __name__ == "__main__":

--- a/src/shrub_prepro/split.py
+++ b/src/shrub_prepro/split.py
@@ -1,12 +1,16 @@
 from sklearn.model_selection import train_test_split
 import shutil
 import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 
-def test_train_test_split(output_dir: str):
+def test_train_split(output_dir: str, label: str = "shrubs"):
     """
     Splits the dataset into training and testing sets based on the indices of image and label files.
-    Assumes that image and label files are named in a consistent format with an index (e.g., 'shrubs_0.tif').
+    Assumes that image and label files are named in a consistent format with an index (e.g., 'shrubs_0.tif') - but the prefix can be different.
+    For our background images, there's only one label (negative_0.tif) - make sure it's included in the training set!
     """
     # Get list of image and label files
     image_files = [
@@ -50,8 +54,8 @@ def test_train_test_split(output_dir: str):
     # Function to move files based on index and type
     def move_files(indices, source_dir, dest_dir):
         for index in indices:
-            image_filename = f"shrubs_{index}.tif"
-            label_filename = f"shrubs_{index}.tif"
+            image_filename = f"{label}_{index}.tif"
+            label_filename = f"{label}_{index}.tif"
 
             source_image_path = os.path.join(source_dir, "images", image_filename)
             source_label_path = os.path.join(source_dir, "labels", label_filename)
@@ -62,14 +66,14 @@ def test_train_test_split(output_dir: str):
             if os.path.exists(source_image_path):
                 shutil.move(source_image_path, dest_image_path)
             else:
-                print(
+                logging.info(
                     f"Warning: Image file not found for index {index}: {source_image_path}"
                 )
 
             if os.path.exists(source_label_path):
                 shutil.move(source_label_path, dest_label_path)
             else:
-                print(
+                logging.info(
                     f"Warning: Label file not found for index {index}: {source_label_path}"
                 )
 
@@ -77,7 +81,7 @@ def test_train_test_split(output_dir: str):
     move_files(train_indices, output_dir, train_dir)
     move_files(test_indices, output_dir, test_dir)
 
-    print(
+    logging.info(
         f"Data split into train ({len(train_indices)} samples) and test ({len(test_indices)} samples)."
     )
-    print(f"Files moved to {train_dir} and {test_dir}.")
+    logging.info(f"Files moved to {train_dir} and {test_dir}.")


### PR DESCRIPTION
Notebook-based training code had been spliced back into the package and not end-to-end tested. This is mostly small fixes to get it fully working again from the commandline

This code has now been used to generate training sets at both 256 and 512 patch size, uploaded to s3 storage. Some complexity around trying to avoid storing duplicate copies of blank labels has been removed, it's not a large amount of data!

